### PR TITLE
Added minor changes for ray version and compatible ipykernel for jupy…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Then use `pip` to install the required dependencies:
 ```
 python3 -m pip install -U pip
 python3 -m pip install -r requirements.txt
+python -m ipykernel install
 ```
 
 Alternatively, if you use `conda` for installing Python packages:
@@ -45,6 +46,7 @@ Alternatively, if you use `conda` for installing Python packages:
 conda create -n ray_tutorial python=3.7
 conda activate ray_tutorial
 python3 -m pip install -r requirements.txt
+conda install ipykernel --name Python3
 ```
 
 Note: if you run into any problems on Python 3.8 with "wheels"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy >= 1.19
 objgraph >= 3.5
 pandas >= 1.1
 pyinstrument >= 3.4
-ray == 1.2.0
+ray >= 1.2.0
 scikit-image >= 0.15
 scikit-learn >= 0.20
 snakeviz >= 2.1


### PR DESCRIPTION
Added minor instructions to README.md so we install the latest versions of ray >=1.2.0 and ensure that jupyter-lab ipykernels and penv python look in the same location for pip installed packages, otherwise you Jupyter notebooks may not be able to find installed packages

Signed-off-by: Jules Damji <dmatrix@comcast.net>